### PR TITLE
Fix teardownObservers never disconnecting observers

### DIFF
--- a/src/mutation-observer.js
+++ b/src/mutation-observer.js
@@ -21,11 +21,11 @@ function observeBonus() {
   log('Creating mutation obvserver on points summary section', summaryClasses[0]);
   lastPointsSummarySection = summaryClasses[0];
   clickBonusButton();
-  observers.push(
-    new MutationObserver(() => {
-      clickBonusButton();
-    }).observe(summaryClasses[0], { childList: true, subtree: true }),
-  );
+  const observer = new MutationObserver(() => {
+    clickBonusButton();
+  });
+  observer.observe(summaryClasses[0], { childList: true, subtree: true });
+  observers.push(observer);
 }
 
 
@@ -33,13 +33,13 @@ function createObservers() {
   if (summaryClasses[0]) observeBonus();
 
   log('Creating document mutation observer');
-  observers.push(
-    new MutationObserver(() => {
-      if (summaryClasses[0] && summaryClasses[0] !== lastPointsSummarySection) {
-        observeBonus();
-      }
-    }).observe(document.body, { subtree: true, childList: true }),
-  );
+  const documentObserver = new MutationObserver(() => {
+    if (summaryClasses[0] && summaryClasses[0] !== lastPointsSummarySection) {
+      observeBonus();
+    }
+  });
+  documentObserver.observe(document.body, { subtree: true, childList: true });
+  observers.push(documentObserver);
 }
 
 function teardownObservers() {


### PR DESCRIPTION
### Bug

In `mutation-observer.js`, observers are stored like this:

```js
observers.push(
  new MutationObserver(() => { clickBonusButton(); }).observe(summaryClasses[0], { childList: true, subtree: true }),
);
```

`MutationObserver.prototype.observe()` returns `undefined`, so the `observers` array ends up holding `undefined` entries instead of the observer instances. `teardownObservers()` then does:

```js
observers.forEach(observer => { if (observer) observer.disconnect(); });
```

The `if (observer)` guard is always false, so **no observer is ever disconnected**.

### Impact

Switching the method from "Mutation Observer" to "Interval" (or re-detecting the points-summary section) never tears down the existing observers. They accumulate on every toggle, leaving stale observers running — potentially alongside the interval.

### Fix

Store each observer instance, call `observe()` on it, then push the instance so `teardownObservers()` can actually disconnect it. Applies to both the points-summary observer in `observeBonus()` and the `document.body` observer in `createObservers()`.
